### PR TITLE
Issue 8 - Undefined Offset Bug (for Single Action Controllers/Closures).

### DIFF
--- a/src/AbstractLogger.php
+++ b/src/AbstractLogger.php
@@ -44,19 +44,22 @@ abstract class AbstractLogger{
     public function logData($request,$response){
         $currentRouteAction = Route::currentRouteAction();
 
-        if($currentRouteAction){
-            list($controller,$action) = explode('@',$currentRouteAction);
+        /*
+         * Some routes will not contain the `@` symbole (e.g. closures, or routes using a single action controller).
+         */
+        if ($currentRouteAction) {
+            if (strpos('@', $currentRouteAction) !== false) {
+                list($controller, $action) = explode('@', $currentRouteAction);
+            } else {
+                // If we get a string, just use that.
+                if (is_string($currentRouteAction)) {
+                    list ($controller, $action) = ["", $currentRouteAction];
+                } else {
+                    // Otherwise force it to be some type of string using `json_encode`.
+                    list ($controller, $action) = ["", (string)json_encode($currentRouteAction)];
+                }
+            }
         }
-        else{
-            list($controller,$action) = ["",""];
-        }
-        $endTime = microtime(true);
-        
-        $implode_models = $this->models;
-
-        array_walk($implode_models, function(&$value, $key) {
-            $value = "{$key} ({$value})";
-        });
 
         $models = implode(', ',$implode_models);
         $this->logs['created_at'] = Carbon::now();


### PR DESCRIPTION
If given a single action controller of closure, the previous code would
unceremoniously crash with an "Undefined offset: 1" error (see Issue #8).

This handles the `$currentRouteAction` differently in that:

1. If we can split it by `@` we do and it will behave as before;
2. If we cannot, we'll check if `$currentRouteAction` is a string and if, and only if it is, we'll set the `$controller` to empty and the current action as the value of `$currentAction` - this is not necessarily ideal _but it is better than crashing_;
3. If it's something else entirely we will use `json_encode` and set the current action to be that value.

We could probably tell if `$currentAction` is a closure and/or a single action controller BUT the main goal of this commit is to stop crashing.

I have tested it on Laravel 6.X.

Resolved #8.